### PR TITLE
seed variable fix

### DIFF
--- a/classes/model.php
+++ b/classes/model.php
@@ -668,7 +668,7 @@ class Model {
 
     private function generate_cache_key() {
         $args = func_get_args();
-        $seed;
+        $seed = '';
 
         foreach( $args as $arg ) {
             $seed .= serialize( $arg );


### PR DESCRIPTION
php seems to complain that seed isn't set without an empty string