### PR TITLE
Update strtodate.php

### DIFF
--- a/helpers/strtodate.php
+++ b/helpers/strtodate.php
@@ -7,7 +7,7 @@ class Strtodate extends Helper {
 		$format	= $this->params->format;
 		$now	= $this->params->now;
 		
-		return date( $format, strtotime( $value, $now ) );
+		return date_i18n( $format, strtotime( $value, $now ) );
     }
 }
 


### PR DESCRIPTION
I suggest we use `date_i18n` instead of the `date` function so we can get localized output. This is useful for example when we're using 'D' as the `format` value.

An other option would be to add a parameter, which toggles this functionality.