### PR TITLE
Test per_page value to prevent dividing by zero.

### DIFF
--- a/helpers/pagination.php
+++ b/helpers/pagination.php
@@ -41,7 +41,12 @@ class Pagination extends Helper {
         ];
         $strings = wp_parse_args( $strings, $defaults );
 
-        $page_count = ceil( $items / $per_page );
+        // Prevent dividing if there are zero items.
+        if(  $per_page > 0 ) {
+            $page_count = ceil( $items / $per_page );
+        } else {
+            $page_count = 1;
+        }
 
         $first_page         = 1;
         $last_page          = $page_count;


### PR DESCRIPTION
This prevents division by zero error that is caused by passing zero as per_page variable in the pagination helper.