### PR TITLE
Image helper

### DIFF
--- a/docs/helpers/image.md
+++ b/docs/helpers/image.md
@@ -1,18 +1,18 @@
 ### Image
 
-The `image` helper returns a markup for `img` tags with proper `srcset` and `sizes` attributes for responsive use. 
+The `image` helper returns a markup for `img` tags with proper `srcset` and `sizes` attributes for responsive use.
 
-You can either give the helper the ID of an image uploaded to WordPress or alternatively use a completely custom URL as the source. 
+You can either give the helper the ID of an image uploaded to WordPress or alternatively use a completely custom URL as the source.
 
 #### An image from WP
 
-When using the helper with an `image ID`, no additional parameters are needed but can be given optionally. The helper fetches the image url from the database and constructs the srcset from the specified WP image sizes. 
+When using the helper with an `id`, you also have to provide a registered WP image size as the `size` parameter. Additional parameters are not needed but can be given optionally. The helper fetches the image url from the database and constructs the srcset from the specified WP image sizes.
 
-``` {@image id=image.id /} ```
+``` {@image id=image.id size="large" /} ```
 
-By default it constructs the same `sizes` attribute for the image as in WP default behaviour. You can also give a custom `sizes` parameter when using the helper with a WP image ID, so that the default WP sizes attribute construction is overriden.
+By default it constructs the same `sizes` attribute for the image as WordPress would. You can also give a custom `sizes` parameter when using the helper with a WP image ID, so that the default WP sizes attribute construction is overriden.
 
-``` {@image id=image.id sizes=Settings.mainImage.sizes /} ```
+``` {@image id=image.id size="my_custom_wp_image_size" sizes=Settings.mainImage.sizes /} ```
 
 #### An image from a custom src
 
@@ -22,15 +22,15 @@ When using the helper with a custom src url, you also have to provide the `srcse
 
 #### The class and alt parameters
 
-With any use case of the helper, you can always optionally provide the `class` and `alt` parameters and they will be added to the returned markup. 
+With any use case of the helper, you can always optionally provide the `class` and `alt` parameters and they will be added to the returned markup.
 
-If you don't provide the alt parameter when using the helper with an image id, it tries to use the alt attribute given to the image when it was uploaded to WordPress. This attribute might be empty in most cases though, so remember to check the final markup for accessibility purposes. 
+If you don't provide the alt parameter when using the helper with an image id, it tries to use the alt attribute given to the image when it was uploaded to WordPress. This attribute might be empty in most cases though, so remember to check the final markup for accessibility purposes.
 
-``` {@image id=image.id class="myclass" alt="An alternative text" /} ```
+``` {@image id=image.id size="medium_large" class="myclass" alt="An alternative text" /} ```
 
 #### A settings model
 
-We recommend using a separate settings model in your DustPress installation for easily defining custom settings for images. This model can be bound to chosen models or even to the middle model which is extended by page and post models. 
+We recommend using a separate settings model in your DustPress installation for easily defining custom settings for images. This model can be bound to chosen models or even to the middle model which is extended by page and post models.
 
 The custom image settings for different images in your web site layout can then be easily acquired for use in the templates.
 
@@ -43,16 +43,17 @@ class Settings extends \DustPress\Model {
         return [
             'mainImage' => [
                 'sizes'  => [
-                    '(min-width: 1280px) 100vw',                    						'(min-width: 768px) 50vw',
+                    '(min-width: 1280px) 100vw',
+                    '(min-width: 768px) 50vw',
                     '100vw',
                 ],
                 'src' => 'https://image.com/example.jpg',
                 'srcset' => [
                     'https://image.com/example-300.jpg 300w',
                     'https://image.com/example-768.jpg 768w',
-                    'https://image.com/example-1024.jpg 1024w',                    
+                    'https://image.com/example-1024.jpg 1024w',
                 ],
             ],
         ];
     }
-} 
+}

--- a/helpers/image.php
+++ b/helpers/image.php
@@ -35,40 +35,50 @@ class Image extends Helper {
 
             } else { // Only the ID given as the original image source.
 
-                // No custom responsive parameters given
-                if ( null === $image_data['srcset'] && null === $image_data['sizes'] ) {
+                if ( null === $image_data['size'] ) {
 
-                    // Return the WordPress default img-tag
-                    // from the full-sized image with a source set.
-                    $the_image_markup = wp_get_attachment_image(
-                        $image_data['id'],
-                        'full',
-                        false,
-                        $image_data['attrs']
-                    );
+                    return '<p><strong>Dustpress image helper error:</strong>
+                            <em>No image size attribute given. When
+                            using the ID, you have to give a registered size name to
+                            the helper. </em></p>';
 
-                    if ( $the_image_markup ) {
+                } else { // ID and size given.
 
-                        return $the_image_markup;
+                    // No custom responsive parameters given
+                    if ( null === $image_data['srcset'] && null === $image_data['sizes'] ) {
 
-                    } else {
+                        // Return the WordPress default img-tag
+                        // from the full-sized image with a source set.
+                        $the_image_markup = wp_get_attachment_image(
+                            $image_data['id'],
+                            $image_data['size'],
+                            false,
+                            $image_data['attrs']
+                        );
 
-                        return '<p><strong>Dustpress image helper error:</strong>
-                                <em>No image found from the database with the given id.</em></p>';
+                        if ( $the_image_markup ) {
 
-                    }
-                } else { // Custom responsive parameters are given.
+                            return $the_image_markup;
 
-                    // SRCSET exists but no SIZES attribute is given.
-                    if ( null === $image_data['sizes'] ) {
+                        } else {
 
-                        return '<p><strong>Dustpress image helper error:</strong>
-                                <em>Srcset exists but no sizes attribute is given.</em></p>';
+                            return '<p><strong>Dustpress image helper error:</strong>
+                                    <em>No image found from the database with the given id.</em></p>';
 
-                    } else { // Both custom responsive parameters and the id is given.
+                        }
+                    } else { // Custom responsive parameters are given.
 
-                        return $this->get_image_markup( $image_data );
+                        // SRCSET exists but no SIZES attribute is given.
+                        if ( null === $image_data['sizes'] ) {
 
+                            return '<p><strong>Dustpress image helper error:</strong>
+                                    <em>Srcset exists but no sizes attribute is given.</em></p>';
+
+                        } else { // Both custom responsive parameters and the id is given.
+
+                            return $this->get_image_markup( $image_data );
+
+                        }
                     }
                 }
             }
@@ -119,6 +129,7 @@ class Image extends Helper {
         $image_data = [
             'id' => null,
             'src' => null,
+            'size' => null,
             'srcset' => null,
             'sizes' => null,
             'attrs' => [],
@@ -132,6 +143,11 @@ class Image extends Helper {
         // Add the src attribute to the data array if it is given.
         if ( isset( $params->src ) ) {
             $image_data['src'] = $params->src;
+        }
+
+        // Add the size attribute to the data array if it is given.
+        if ( isset( $params->size ) ) {
+            $image_data['size'] = $params->size;
         }
 
         // Add the srcset attribute to the data array if it is given.
@@ -173,8 +189,12 @@ class Image extends Helper {
 
         } else { // Else get the images src from WP.
 
+            // Get the image from WP.
+            $image_src_array = wp_get_attachment_image_src( $image_data['id'],
+            $image_data['size'] );
+
             // Construct the beginning markup of the image string if the image is found.
-            if ( $image_src_array = wp_get_attachment_image_src( $image_data['id'], 'full' ) ) {
+            if ( $image_src_array ) {
 
                 $image_src = $image_src_array[0];
                 $image_width = $image_src_array[1];


### PR DESCRIPTION
Added `size` as a compulsory parameter, so that developers will be more aware of the base size used to generate the image src. This further minimizes the risk of rendering huge images in the client.