### PR TITLE
Add check if currently on a static page for posts

### DIFF
--- a/helpers/menu.php
+++ b/helpers/menu.php
@@ -260,6 +260,8 @@ class Menu extends Helper {
 
         $return = (    \get_the_ID() == $item->object_id
                 &&  'post_type' == $item->type )
+                // Check if on a static page that shows posts.
+                ||  ( \is_home() && ! \is_front_page() && \get_queried_object_id() == $item->object_id )
                 ||  ( $item->object_id == $term_id && 'taxonomy' == $item->type )
                 ||  ( $item->object_id == $override );
 


### PR DESCRIPTION
Checks if we are on the page that has been set to show posts in Settings->Reading->Front page displays.