### PR TITLE
Use date_format from options if no format param

### DIFF
--- a/helpers/strtodate.php
+++ b/helpers/strtodate.php
@@ -4,7 +4,11 @@ namespace DustPress;
 class Strtodate extends Helper {
     public function output() {
 		$value 	= $this->params->value;
-		$format	= $this->params->format;
+	    	if ( isset( $this->params->format ) ) {
+			$format	= $this->params->format;
+		} else {
+			$format = get_option( 'date_format' );
+		}
 		$now	= $this->params->now;
 		
 		return date_i18n( $format, strtotime( $value, $now ) );


### PR DESCRIPTION
If no format parameter given. Use the date format defined in 'Date Format' on Settings > General panel.