### PR TITLE
override wp-activate.php

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+##[Unreleased]
+### Added
+- Model and partial containing the basic functionality of the default user activate view.
+
+### Changed
+- Modify DustPress to notice when user is on user activate view and load custom view instead.
+
 ## [1.6.11] - 2017-10-30
 ### Changed
 - Optimized file loading routines to reduce loading times

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ##[Unreleased]
 ### Added
-- Model and partial containing the basic functionality of the default user activate view.
+- Model and partial containing the basic functionality of the default wp-activate.php file.
 
 ### Changed
-- Modify DustPress to notice when user is on user activate view and load custom view instead.
+- Modify core so that when wp-activate.php is loaded the execution is stopped and DustPress creates its own instance.
 
 ## [1.6.11] - 2017-10-30
 ### Changed

--- a/README.md
+++ b/README.md
@@ -740,7 +740,7 @@ composer require devgeniem/dustpress-comments
 ```
 
 # Overriding default templates
-DustPress offers a way to override WordPress default templates that could not otherwise be edited.
+DustPress offers a way to override WordPress' default templates that othewise are not easily editable.
 
 At the moment it's possible to modify:
 

--- a/README.md
+++ b/README.md
@@ -738,3 +738,10 @@ Get the Comments helper from [Geniem Github](https://github.com/devgeniem/dustpr
 ```
 composer require devgeniem/dustpress-comments
 ```
+
+# Overriding default templates
+DustPress offers a way to override WordPress default templates that could not otherwise be edited.
+
+At the moment it's possible to modify:
+
+- wp-activate.php ([docs](https://github.com/devgeniem/dustpress/blob/master/docs/customize-wp/user-activate.md))

--- a/docs/customize-wp/user-activate.md
+++ b/docs/customize-wp/user-activate.md
@@ -1,0 +1,61 @@
+### Custom wp-activate.php
+
+Upon user creation an email is sent to the user's email address containing an activation link. Opening this link leads to /wp-activate.php page where user can activate their account.
+
+The view is printed out from wp-activate.php and cant' be modified easily. But in DustPress we do this for you. In the core we stop the wp-activate.php execution and run our own model and view instead.
+
+These can be found in `models/user-activate.php` and `partials/user-activate.dust`. They mimic the original file but you can easily override the partial or even the model in your theme. 
+
+Be careful when editing the user-activate.php that nothing breaks! 
+
+### Files
+```
+models/user-activate.php
+partials/user-activate.dust
+```
+
+### Model 
+The default user activate model has two functions `Print` and `State`. 
+#### State
+State method runs through the same code found in wp-activate. It collects all strings that need to be outputted and passes them to the Print function. Also it sets an arbitrary state based on the code. This state is returned to the view.
+
+State comes in handy when modifying the view. For example we check for `no-key` state to define if the didn't contain an activation key and show a form to fill that if that is the case.
+```
+{@eq key=State value="no-key" }`
+    ... form code ..
+{/eq}
+
+```
+
+#### States
+ - **no-key** 
+    - No activation key is set. Normally outputs form for user to give the key.
+ - **site-active-mail**
+    - Site has been activated and mail sent to user.
+ - **account-active-mail**
+    - Account has been activated and mail sent to user.
+ - **account-active-no-mail**
+    - Account has been activated but no mail is sent. Normally outputs username and password.
+ - **error**                    
+    - Error occurred during activation. Sets error message to print['error'].
+
+#### Print
+
+Print returns to the view all the translated strings that wp-activate.php would output. They can be used in the partial with `{Print.string_name}`. 
+
+#### Strings
+- **title** 
+    - Site header
+- **wp-activate-link** 
+    - Activation link
+- **message** 
+    - Translated message
+- **error** 
+    - Possible error
+- **username** 
+    - User's loginname
+- **password** 
+    - Translated string of "Your chosen password"
+
+### Multisite
+This is also tested in multisite. Actually the idea to create this arose from problems with wp-activate.php on multisite.

--- a/models/user-activate.php
+++ b/models/user-activate.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ *  Replaces wp-activate.php and offers user way to make custom partial for it.
+ */
+class UserActivate extends \DustPress\Model {
+
+    private $state;
+    private $print;
+
+    /**
+     * Returns the state of the page and sets the right strings for printing.
+     * States:
+     *     no-key                   No activation key is set. Normally outputs form for user to give the key.
+     *     site-active-mail         Site has been activated and mail sent to user.
+     *     account-active-mail      Account has been activated and mail sent to user.
+     *     account-active-no-mail   Account has been activated but no mail is sent. Normally outputs username and password.
+     *     error                    Error occurred during activation. Sets error message to print['error'].
+     *
+     * @param   N /A
+     *
+     * @return  $state (string)    State of the view.
+     */
+    public function State() {
+        if ( empty( $_GET['key'] ) && empty( $_POST['key'] ) ) {
+            // activation key required
+            $state                             = "no-key";
+            $this->print['title']            = __( 'Activation Key Required' );
+            $this->print['wp-activate-link'] = network_site_url( 'wp-activate.php' );
+        }
+        else {
+            $key    = ! empty( $_GET['key'] ) ? $_GET['key'] : $_POST['key'];
+            $result = wpmu_activate_signup( $key );
+            if ( is_wp_error( $result ) ) {
+                if ( 'already_active' == $result->get_error_code() || 'blog_taken' == $result->get_error_code() ) {
+                    $signup       = $result->get_error_data();
+                    $this->signup = $signup;
+                    $this->print['title'] = __( 'Your account is now active!' );
+                    if ( $signup->domain . $signup->path == '' ) {
+                        // account active and email sent
+                        $state = "account-active-mail";
+                        $this->print['message'] = sprintf( /* translators: 1: login URL, 2: username, 3: user email, 4: lost password URL */
+                            __( 'Your account has been activated. You may now <a href="%1$s">log in</a> to the site using your chosen username of &#8220;%2$s&#8221;. Please check your email inbox at %3$s for your password and login instructions. If you do not receive an email, please check your junk or spam folder. If you still do not receive an email within an hour, you can <a href="%4$s">reset your password</a>.' ), network_site_url( 'wp-login.php', 'login' ), $signup->user_login, $signup->user_email, wp_lostpassword_url() );
+                    }
+                    else {
+                        // site active and email sent
+                        $state = "site-active-mail";
+                        /* translators: 1: site URL, 2: site domain, 3: username, 4: user email, 5: lost password URL */
+                        $this->print['message'] = sprintf( /* translators: 1: site URL, 2: site domain, 3: username, 4: user email, 5: lost password URL */
+                            __( 'Your site at <a href="%1$s">%2$s</a> is active. You may now log in to your site using your chosen username of &#8220;%3$s&#8221;. Please check your email inbox at %4$s for your password and login instructions. If you do not receive an email, please check your junk or spam folder. If you still do not receive an email within an hour, you can <a href="%5$s">reset your password</a>.' ), 'http://' . $signup->domain, $signup->domain, $signup->user_login, $signup->user_email, wp_lostpassword_url() );
+                    }
+                }
+                else {
+                    // error occurred during activation
+                    $state                  = "error";
+                    $this->print['error'] = $result->get_error_message();
+                }
+            }
+            else {
+                $this->print['username'] = $user->user_login;
+                $this->print['password'] = $result['password'];
+                $state = "account-active-no-mail";
+                if ( $url && $url != network_home_url( '', 'http' ) ) {
+                    switch_to_blog( (int) $result['blog_id'] );
+                    $login_url = wp_login_url();
+                    restore_current_blog();
+                    //log in link to blog
+                    /* translators: 1: site URL, 2: login URL */
+                    $this->print['message'] = sprintf( __( 'Your account is now activated. <a href="%1$s">View your site</a> or <a href="%2$s">Log in</a>' ), $url, esc_url( $login_url ) );
+                }
+                else {
+                    //log in link to main site
+                    /* translators: 1: login URL, 2: network home URL */
+                    $this->print['message'] = sprintf( __( 'Your account is now activated. <a href="%1$s">Log in</a> or go back to the <a href="%2$s">homepage</a>.' ), network_site_url( 'wp-login.php', 'login' ), network_home_url() );
+                }
+            }
+        }
+        $this->state = $state;
+
+        return $state;
+    }
+
+    /*
+     * Returns strings for printing.
+     *  @return  $this->print (string) Messages for the view.
+     */
+    public function Print() {
+        return $this->print;
+    }
+
+}

--- a/models/user-activate.php
+++ b/models/user-activate.php
@@ -80,8 +80,19 @@ class UserActivate extends \DustPress\Model {
         return $state;
     }
 
-    /*
+
+
+    /**
      * Returns strings for printing.
+     *
+     * Available strings:
+     *  title - Site header
+     *  wp-activate-link - Activation link
+     *  message - Translated message.
+     *  error - Possible error
+     *  username - User's loginname
+     *  password - Translated string of "Your chosen password".
+     *
      *  @return  $this->print (string) Messages for the view.
      */
     public function Print() {

--- a/partials/user-activate.dust
+++ b/partials/user-activate.dust
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<head>
+    {@wphead /}
+</head>
+<body>
+    {#UserActivate}
+
+    <div id="signup-content" class="widecolumn">
+        <div class="wp-activate-container">
+
+            {! Print the title !}
+            <h2> {@s s=Print.title /} </h2>
+
+            {@eq key=State value="account-active-no-mail" }
+                <div id="signup-welcome">
+                    <p><span class="h3"> {@s s="Username:" /} </span> {User.username}</p>
+                    <p><span class="h3"> {@s s="Password:" /} </span> {User.password}</p>
+                </div>
+            {/eq}
+
+            {! Print message if we have it !}
+            {?Print.message}
+                <p> {@s s=Print.message /} </p>
+            {/Print.message}
+
+            {! Print error if we have it !}
+            {?Print.error}
+                <p> {@s s=Print.error /} </p>
+            {/Print.error}
+
+            {! If no key set, print form to ask for it !}
+            {@eq key=State value="no-key" }
+                <form name="activateform" id="activateform" method="post" action="{Print.wp-activate-link}">
+                    <p>
+                        <label for="key">{@s s="Activation Key:" /}</label>
+                        <br /><input type="text" name="key" id="key" value="" size="50" />
+                    </p>
+                    <p class="submit">
+                        <input id="submit" type="submit" name="Submit" class="submit" value="{@s s="Activate" /}" />
+                    </p>
+                </form>
+            {/eq}
+
+        </div>
+    </div>
+
+    <script type="text/javascript">
+        var key_input = document.getElementById('key');
+        key_input && key_input.focus();
+    </script>
+    {/UserActivate}
+    {@wpfooter /}
+</body>
+</html>


### PR DESCRIPTION
This change allows theme developer to override or extend the basic wp-activate.php template in a DustPress way.
Introduces two new files:
- partials/user-activate.dust
- models/user-activate.php

which mimic the default Wordpress' way of doing things.

Adds filter  `dustpress/template/useractivate`which helps extending the existing UserActivate class.
For example:
```
add_filter('dustpress/template/useractivate', function( $template ) { return 'CustomUserActivate'; } );
```
Tested with multisite.

You can read more from `docs/customize-wp/user-activate.md`