### PR TITLE
Adds menu location to the menu helper data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [1.12.0] - 2018-01-29
 
 ### Added
-- Adds menu location to the menu helper data. This helps developers to filter menu by menu `location`.
+- Menu location to the menu helper data.
+- Filters for menu object and menu items by the menu location.
 
 ## [1.11.0] - 2018-01-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.12.0] - 2018-01-29
+
+### Added
+- Adds menu location to the menu helper data. This helps developers to filter menu by menu `location`.
+
 ## [1.11.0] - 2018-01-26
 
 ### Added

--- a/dustpress.php
+++ b/dustpress.php
@@ -6,7 +6,7 @@ Description: Dust.js templating system for WordPress
 Author: Miika Arponen & Ville Siltala / Geniem Oy
 Author URI: http://www.geniem.com
 License: GPLv3
-Version: 1.11.0
+Version: 1.12.0
 */
 
 final class DustPress {

--- a/helpers/menu.php
+++ b/helpers/menu.php
@@ -187,10 +187,10 @@ class Menu extends Helper {
 
                 // return menu object and menu items
                 $menu = [];
-                $menu['menu_object'] = $menu_object;
-                $menu['menu_items']  = $built_menu_items;
+                $menu['menu_object'] = apply_filters( 'dustpress/menu/object/location=' . $menu_object->location, $menu_object );
+                $menu['menu_items'] = apply_filters( 'dustpress/menu/items/location=' . $menu_object->location, $built_menu_items );
 
-                return apply_filters( "dustpress/menu", $menu );
+                return apply_filters( 'dustpress/menu', $menu );
         }
     }
 

--- a/helpers/menu.php
+++ b/helpers/menu.php
@@ -135,16 +135,24 @@ class Menu extends Helper {
      */
     public static function get_menu_data( $menu_name, $parent = 0, $override = null, $menu_id_given = false ) {
 
+        $locations = \get_nav_menu_locations();
+
         if ( $menu_id_given ) {
             $menu_object = \wp_get_nav_menu_object( $menu_name );
         } else {
-            if ( ( $locations = \get_nav_menu_locations() ) && isset( $locations[ $menu_name ] ) ) {
+            if ( ( $locations ) && isset( $locations[ $menu_name ] ) ) {
                 $menu_object = \wp_get_nav_menu_object( $locations[ $menu_name ] );
             }
         }
 
         if ( isset( $menu_object) ) {
             $menu_items = \wp_get_nav_menu_items( $menu_object );
+
+            // Add menu object location to the menu object.
+            // You can use this to filter specific menu items.
+            if ( ! empty( $menu_object->term_id ) && is_array( $locations ) ) {
+                $menu_object->location = array_search( $menu_object->term_id, $locations );
+            }
         }
         else {
             return null;


### PR DESCRIPTION
## [1.12.0] - 2018-01-29

### Added
- Adds menu location to the menu helper data. This helps developers to filter menu by menu `location`.

Example of filtering in this way:

```
add_filter( 'dustpress/menu', function( $data ) {

    if ( isset( $data['menu_object']) ) {
        if ( $data['menu_object']->location === 'nav_location' ) {
            if ( ! empty( $data['menu_items'] ) && is_array( $data['menu_items'] ) ) {
                foreach ( $data['menu_items'] as &$menu_item ) {
                    // Do your magic here.
                }
            }
        }
    }

    return $data;
});
```