### PR TITLE
Preview fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.16.2] - 2018-09-03
+
+### Changed
+- Fixed 'dustpress/router' filter for WordPress preview functionality.
+- Removed unnecessary `$id` parameter from `get_post_meta()`.
+- Changed functions `get_post()` and `get_acf_post()` to use global post if desired post id same as global post.
+
 ## [1.16.1] - 2018-06-20
 
 ### Added

--- a/classes/query.php
+++ b/classes/query.php
@@ -455,11 +455,11 @@ class Query {
 	 */
 	private static function cast_post_to_type( $post, $type ) {
 
-        if ( $type === 'ARRAY_N' ) {
-            $post = array_values( $_post->to_array() );
-        } elseif ( $type === 'ARRAY_A' ) {
+		if ( $type === 'ARRAY_A' ) {
 			$post = $post->to_array();
-		}
+		} elseif ( $type === 'ARRAY_N' ) {
+            $post = array_values( $post->to_array() );
+        }
 
 		return $post;
 	}

--- a/classes/query.php
+++ b/classes/query.php
@@ -49,7 +49,7 @@ class Query {
 		extract( $options );
 
 		// If id is not the same as global post get_post by id.
-		if ( $id ) {
+		if ( $post->ID !== $id ) {
 			$post = get_post( $id );
 		}
 
@@ -83,7 +83,7 @@ class Query {
 	 *
      * @return array|object|null Type corresponding to output type on success or null on failure.
 	 */
-	public static function get_acf_post( $post_id = null, $args = array() ) {
+	public static function get_acf_post( $id = null, $args = array() ) {
 
 		global $post;
 
@@ -100,8 +100,8 @@ class Query {
 
 		extract( $options );
 
-		if ( $post_id ) {
-			$acfpost = get_post( $post_id );
+		if ( $post->ID !== $id ) {
+			$acfpost = get_post( $id );
 		} else {
 			$acfpost = $post;
 		}

--- a/dustpress.php
+++ b/dustpress.php
@@ -6,7 +6,7 @@ Description: Dust.js templating system for WordPress
 Author: Miika Arponen & Ville Siltala / Geniem Oy
 Author URI: http://www.geniem.com
 License: GPLv3
-Version: 1.16.1
+Version: 1.16.2
 */
 
 final class DustPress {
@@ -194,8 +194,8 @@ final class DustPress {
             // Filter for wanted post ID
             $new_post = apply_filters( 'dustpress/router', $post_id );
 
-            // If developer wanted a post ID, make it happen
-            if ( ! is_null( $new_post ) ) {
+            // If developer wanted a post by post ID.
+            if ( $new_post !== $post_id ) {
                 $post = get_post( $new_post );
 
                 setup_postdata( $post );


### PR DESCRIPTION
### Changed
- Fixed 'dustpress/router' filter for WordPress preview functionality.
- Removed unnecessary `$id` parameter from `get_post_meta()`.
- Changed functions `get_post()` and `get_acf_post()` to use global post if desired post id same as global post.