### PR TITLE
Fix menuitem recursive level index

### DIFF
--- a/partials/menuitem.dust
+++ b/partials/menuitem.dust
@@ -13,6 +13,7 @@
 		{/sub_menu}
 		{?sub_menu}
 			</ul>
+			{@set key="depth_now" subtract=1 /}
 		{/sub_menu}
 	{/eq}
 {/show_submenu}


### PR DESCRIPTION
This fixes the index in cases where there's many sub items inside sub items. 

When we start to go through sub menu items and their sub menu items, the depth grows by 1 level on each recursion. We also need to subtract the added level of depth when "exiting" from each sub menu item.