### PR TITLE
Cache DustPHP template file paths during runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Cache DustPHP template file paths during runtime to prevent multiple recursive directory searches for same template requests.
+
 ## [1.17.0] - 2018-10-19
 
 ### Fixed

--- a/dust/Dust.php
+++ b/dust/Dust.php
@@ -24,6 +24,12 @@ namespace Dust
         public $templates = [];
 
         /**
+         * Stores found template paths for faster template loading.
+         * @var array
+         */
+        protected static $dustFileCache = [];
+
+        /**
          * @var array
          */
         public $filters = [];
@@ -136,10 +142,16 @@ namespace Dust
          * @return null|string
          */
         public function resolveAbsoluteDustFilePath($path, $basePath = NULL) {
+
             //add extension if necessary
             if(substr_compare($path, self::FILE_EXTENSION, -5, 5) !== 0)
             {
                 $path .= self::FILE_EXTENSION;
+            }
+
+            // Get from cache if the file is already found.
+            if ( isset( static::$dustFileCache[ $path ] ) ) {
+                return static::$dustFileCache[ $path ];
             }
 
             //try the current path
@@ -154,10 +166,17 @@ namespace Dust
             foreach ( $this->includedDirectories as $directory ) {
                 foreach ( new \RecursiveIteratorIterator( new \RecursiveDirectoryIterator( $directory, \RecursiveDirectoryIterator::SKIP_DOTS ) ) as $file ) {
                     if ( substr_compare($file, "/".$path, strlen($file)-strlen("/".$path), strlen("/".$path)) === 0 ) {
+
+                        // Cache the found file.
+                        static::$dustFileCache[ $path ] = (string) $file;
+
                         return (string)$file;
                     }
                 }
             }
+
+            // Cache the not found result to prevent subsequent searches.
+            static::$dustFileCache[ $path ] = NULL;
 
             return NULL;
         }


### PR DESCRIPTION
### Added
- Cache DustPHP template file paths during runtime to prevent multiple recursive directory searches for same template requests.