### PR TITLE
Fix a bug in the pagination helper first page handling.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed a bug in the pagination helper first page handling.
+
 ## [1.21.0] - 2019-02-01
 
 ### Added

--- a/helpers/pagination.php
+++ b/helpers/pagination.php
@@ -76,7 +76,8 @@ class Pagination extends Helper {
             if ( $cur_page === $first_page ) {
                 $hellip_start  = '';
                 $on_first_page = true;
-                for ( $i = 0; $i < $visible; $i++ ) {
+                $max = ( $page_count < $visible ) ? $page_count : $visible;
+                for ( $i = 0; $i < $max; $i++ ) {
                     if ( ( $i + 1 ) > $page_count ) {
                         $hellip_end = '';
                         break;

--- a/helpers/pagination.php
+++ b/helpers/pagination.php
@@ -76,7 +76,7 @@ class Pagination extends Helper {
             if ( $cur_page === $first_page ) {
                 $hellip_start  = '';
                 $on_first_page = true;
-                for ( $i = 0; $i < 7; $i++ ) {
+                for ( $i = 0; $i < $visible; $i++ ) {
                     if ( ( $i + 1 ) > $page_count ) {
                         $hellip_end = '';
                         break;
@@ -131,7 +131,7 @@ class Pagination extends Helper {
                     $hellip_end = '';
                 }
 
-                // display max number of pages
+                // Display max number of pages.
                 $max_pages = $start + ( $visible - 1 );
                 if ( $max_pages <= $page_count ) {
                     for ( $i = $start; $i <= $max_pages; $i++ ) {
@@ -142,7 +142,7 @@ class Pagination extends Helper {
                         }
                     }
                 }
-                // display less
+                // Display less.
                 else {
                     for ( $i = $start; $i <= $end; $i++ ) {
                         $pages[ $i ]       = (object) [];


### PR DESCRIPTION
If the number of displayed neighbours was changed with a parameter, the first page handling would display incorrect amount if visible items. I fixed this by changing the correct variable into the first page handling loop.