### PR TITLE
Fixed pagination helper active state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [hotfix-pagination-helper-active-state] - 2019-02-04
+
+### Added
+
+- Pagination helper fixed $page_count to return int not float. This caused failure on current page active state in some cases.
+
 ## [1.21.0] - 2019-02-01
 
 ### Added

--- a/helpers/pagination.php
+++ b/helpers/pagination.php
@@ -58,7 +58,7 @@ class Pagination extends Helper {
 
         // Prevent dividing if there are zero items.
         if ( $per_page > 0 ) {
-            $page_count = ceil( $items / $per_page );
+            $page_count = (int) ceil( $items / $per_page );
         }
         else {
             $page_count = 1;


### PR DESCRIPTION
- Pagination helper fixed $page_count to return int not float. This caused failure on current page active state in some cases.