### PR TITLE
Fix for menu helper build_menu method when ->classes is not an array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Fixed case in menu helper build_menu method when $item->classes is not an array (e.g. certain cases in Customizer)
+
 ## [1.21.3] - 2019-03-04
 
 ### Fixed

--- a/helpers/menu.php
+++ b/helpers/menu.php
@@ -231,6 +231,11 @@ class Menu extends Helper {
                 if ( $item->menu_item_parent == $parent ) {
                     $item->sub_menu = self::build_menu( $menu_items, $item->ID, $item->object, $override );
 
+                    // Make sure $item->classes is an array. Needed to work with the Customizer.
+                    if ( ! is_array( $item->classes ) ) {
+                        $item->classes = [];
+                    }
+
                     if ( is_array( $item->sub_menu ) && count( $item->sub_menu ) > 0 ) {
                         $item->classes[] = 'menu-item-has-children';
                     }


### PR DESCRIPTION
While editing a menu within the Customizer, or after saving a Customizer draft, there were still cases where the `classes` property of a menu item could be an empty string within the `build_menu` method of the menu helper. 

Some cases were caught by a previous PR, but not all. This PR should hopefully take care of the rest.

Note: This PR does still not address issue #105.

Fixes #109