### PR TITLE
Fixed a bug in user-active.php caused by a change in WP core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Fixed a bug in user-active.php caused by a change in WP core.
+
 ## [1.24.1] - 2019-08-20
 
 ### Fixed

--- a/models/user-activate.php
+++ b/models/user-activate.php
@@ -23,14 +23,25 @@ class UserActivate extends \DustPress\Model {
      * @return  $state (string)    State of the view.
      */
     public function State() {
-        if ( empty( $_GET['key'] ) && empty( $_POST['key'] ) ) {
+        // Get the key from cookie if set
+        $activate_cookie = 'wp-activate-' . COOKIEHASH;
+
+        if ( isset( $_COOKIE[ $activate_cookie ] ) ) {
+            $key = $_COOKIE[ $activate_cookie ];
+        }
+
+        if ( ! $key && empty( $_GET['key'] ) && empty( $_POST['key'] ) ) {
             // activation key required
-            $state                             = "no-key";
+            $state                           = "no-key";
             $this->print['title']            = __( 'Activation Key Required' );
             $this->print['wp-activate-link'] = network_site_url( 'wp-activate.php' );
         }
         else {
-            $key    = ! empty( $_GET['key'] ) ? $_GET['key'] : $_POST['key'];
+            // Get key from GET or POST if not set via cookie
+            if ( ! $key ) {
+                $key = ! empty( $_GET['key'] ) ? $_GET['key'] : $_POST['key'];
+            }
+
             $result = wpmu_activate_signup( $key );
             if ( is_wp_error( $result ) ) {
                 if ( 'already_active' == $result->get_error_code() || 'blog_taken' == $result->get_error_code() ) {


### PR DESCRIPTION
The change in WP core caused a faulty redirect when activating a user via the link received account activation in email.