### PR TITLE
Fixed the menu helper partial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+- Fixed the menu helper partial, which printed out an empty ul element when the requested menu doesn't exist.
+
 ## [1.25.0-beta] - 2019-19-20
 
 ### Fixed
@@ -20,7 +25,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Error handlers now send HTTP status code 500 in error situations.
 
-## [1.23.2] - 2019-06<<<<
+## [1.23.2] - 2019-06-05
+
 ### Fixed
 - A bug in how class names with multiple word spaces should be formed.
 

--- a/partials/menu.dust
+++ b/partials/menu.dust
@@ -1,6 +1,9 @@
-<ul class="menu-depth-1{?ul_classes} {ul_classes}{/ul_classes}"{?ul_id} id="{ul_id}"{/ul_id}>
-	{#items}
-		{@set key="depth_now" value=1 /}
-		{>"{menuitem_partial}" /}
-	{/items}
-</ul>
+{! Print out the menu only when the menu_object variable is not NULL !}
+{?menu_object}
+	<ul class="menu-depth-1{?ul_classes} {ul_classes}{/ul_classes}"{?ul_id} id="{ul_id}"{/ul_id}>
+		{#items}
+			{@set key="depth_now" value=1 /}
+			{>"{menuitem_partial}" /}
+		{/items}
+	</ul>
+{/menu_object}


### PR DESCRIPTION
Fixed the menu helper partial, which printed out an empty `ul` element when the requested menu doesn't exist.