### PR TITLE
Added a filter for image helper $image_data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [image-helper-data-filter] - 2019-12-03
+
+### Added
+- A filter for image helper `$image_data`.
+
 ## [1.26.3] - 2019-12-03
 
 ### Fixed

--- a/helpers/image.php
+++ b/helpers/image.php
@@ -183,6 +183,8 @@ class Image extends Helper {
             $image_data['attrs']['alt'] = $params->alt;
         }
 
+        $image_data = \apply_filters( 'dustpress/image/image_data', $image_data );
+
         return $image_data;
     }
 


### PR DESCRIPTION
This adds a filter for image helper $image_data.

This way we can add attributes for the images added with @image helper.
After the changes this issue will be fixed.
https://github.com/devgeniem/dustpress/issues/136

loading attribute can added like so for all the images at once.

```
/**
 * Filter image helper data.
 *
 * @param array $image_data DustPress image helper data.
 *
 * @return mixed
 */
function filter_image_helper_data( $image_data ) {

    $image_data['attrs']['loading'] = 'lazy';

    return $image_data;
}

\add_action( 'dustpress/image/image_data', 'filter_image_helper_data', 1 );
```