### PR TITLE
Fixes to performance monitoring

### DIFF
--- a/classes/model.php
+++ b/classes/model.php
@@ -315,11 +315,15 @@ class Model {
 
         $methods = array_reverse( $methods );
 
+        $perf_monitoring_enabled = dustpress()->performance_enabled ?? false;
+
         // Loop through all public methods and run the ones we wanted to deliver the data to the views.
         foreach ( $methods as $class => $class_methods ) {
             foreach ( $class_methods as $name => $m ) {
-                $perf_key = $this->perf_key( $m );
-                dustpress()->start_performance( $perf_key );
+                if ( $perf_monitoring_enabled ) {
+                    $perf_key = $this->perf_key( $m );
+                    dustpress()->start_performance( $perf_key );
+                }
 
                 if ( is_array( $m ) ) {
                     if ( isset( $m[1] ) && is_string( $m[1] ) ) {
@@ -367,7 +371,9 @@ class Model {
                     }
                 }
 
-                dustpress()->save_performance( $perf_key );
+                if ( $perf_monitoring_enabled ) {
+                    dustpress()->save_performance( $perf_key );
+                }
 
                 if ( $this->terminated ) {
                     break 2;


### PR DESCRIPTION
- Fixes performance monitoring of performance monitoring hooks
- Disables performance monitoring from `WP_CLI`, `WP_IMPORTING` and enables it when DustPress Debugger can be found and is active
- Sorts hooks array in measure_hooks_performance and removes duplicate entries (get_sidebar and get_search_form)
