### PR TITLE
Feature: {@password no_form=true}

### DIFF
--- a/helpers/password.php
+++ b/helpers/password.php
@@ -1,14 +1,22 @@
 <?php
+/**
+ * Password protection.
+ */
+
 namespace DustPress;
 
+/**
+ * Password protection helper
+ *
+ * @example {@password}Anything worth password protection, will be replaced with password form.{/password}
+ * @example {@password no_form=true}Should be used with one instance where form isn't hidden.{/password}
+ *
+ * @package DustPress
+ */
 class Password extends Helper {
     public function init() {
-        if ( isset( $this->params->id ) ) {
-            $id = $this->params->id;
-        }
-        else {
-            $id = get_the_ID();
-        }
+        $id      = $this->params->id ?? get_the_ID();
+        $no_form = isset( $this->params->no_form );
 
         $post = get_post( $id );
 
@@ -16,19 +24,28 @@ class Password extends Helper {
         if ( empty( $post->post_password ) || ! post_password_required( $id ) ) {
             return $this->chunk->render( $this->bodies->block, $this->context );
         }
-        else {
-            if ( post_password_required( $id ) ) {
-                // Populate data object to be passed to the password form template
-                $data = new \stdClass();
-                $data->url = esc_url( site_url( 'wp-login.php?action=postpass', 'login_post' ) );
-                $data->label = 'pwbox-'. $id;
-                return $this->chunk->write( dustpress()->render([
-                    'partial' => 'password_form',
-                    'data'    => $data,
-                    'echo'    => false
-                ]) );
+
+        if ( post_password_required( $id ) ) {
+
+            // If used like {@password no_form=anything} the contents are hidden,
+            // but no password_form partial will be rendered.
+            if ( $no_form ) {
+                return $this->chunk->write( '' );
             }
+
+            // Populate data object to be passed to the password form template
+            $data        = new \stdClass();
+            $data->url   = esc_url( site_url( 'wp-login.php?action=postpass', 'login_post' ) );
+            $data->label = 'pwbox-' . $id;
+
+            return $this->chunk->write( dustpress()->render( [
+                'partial' => 'password_form',
+                'data'    => $data,
+                'echo'    => false,
+            ] ) );
         }
+
+        return $this->chunk->render( $this->bodies->block, $this->context );
     }
 }
 


### PR DESCRIPTION
This PR adds some documentation, phpcs styling, and one feature.

It was impossible to hide several parts of a document without having multiple password fields on the page.

This feature adds optional "no_form" parameter, which when set will return empty string and no password_form partial.

Example:

```
<header>
    {@password}
        This part is in the hero element, containing filtering controls for example.
    {/password}
</header>
<div>
    {@password no_form=true}
        {@content /}
    {/password}
</div>
```

Without this feature, the page would have two password fields.
