### PR TITLE
fix-templates-for-pages-and-cpts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.34.4] - 2021-10-14
+- Fix template usage for CPT posts. Also allow page templates to use any name, as intended in WP.
 
 ## [Released]
 

--- a/dustpress.php
+++ b/dustpress.php
@@ -545,11 +545,11 @@ final class DustPress {
             $type = get_post_type();
 
             $hierarchy[ 'is_single' ] = [
-                $this->dashed_to_camelcase( $template ),
                 'Single' . $this->dashed_to_camelcase( $template, '_' ),
                 'Single' . $this->dashed_to_camelcase( $template ),
                 'Single' . $this->dashed_to_camelcase( $type, '_' ),
                 'Single' . $this->dashed_to_camelcase( $type ),
+                $this->dashed_to_camelcase( $template ),
                 'Single'
             ];
         }

--- a/dustpress.php
+++ b/dustpress.php
@@ -424,6 +424,7 @@ final class DustPress {
 
         if ( is_page() ) {
             $hierarchy[ 'is_page' ] = [
+                $this->dashed_to_camelcase( $template ),
                 'Page' . $this->dashed_to_camelcase( $template, '_' ),
                 'Page' . $this->dashed_to_camelcase( $template ),
                 'Page' . $this->dashed_to_camelcase( $post->post_name, '_' ),
@@ -544,6 +545,7 @@ final class DustPress {
             $type = get_post_type();
 
             $hierarchy[ 'is_single' ] = [
+                $this->dashed_to_camelcase( $template ),
                 'Single' . $this->dashed_to_camelcase( $template, '_' ),
                 'Single' . $this->dashed_to_camelcase( $template ),
                 'Single' . $this->dashed_to_camelcase( $type, '_' ),

--- a/dustpress.php
+++ b/dustpress.php
@@ -547,9 +547,9 @@ final class DustPress {
             $hierarchy[ 'is_single' ] = [
                 'Single' . $this->dashed_to_camelcase( $template, '_' ),
                 'Single' . $this->dashed_to_camelcase( $template ),
-                $this->dashed_to_camelcase( $template ),
                 'Single' . $this->dashed_to_camelcase( $type, '_' ),
                 'Single' . $this->dashed_to_camelcase( $type ),
+                $this->dashed_to_camelcase( $template ),
                 'Single'
             ];
         }

--- a/dustpress.php
+++ b/dustpress.php
@@ -424,9 +424,9 @@ final class DustPress {
 
         if ( is_page() ) {
             $hierarchy[ 'is_page' ] = [
-                $this->dashed_to_camelcase( $template ),
                 'Page' . $this->dashed_to_camelcase( $template, '_' ),
                 'Page' . $this->dashed_to_camelcase( $template ),
+                $this->dashed_to_camelcase( $template ),
                 'Page' . $this->dashed_to_camelcase( $post->post_name, '_' ),
                 'Page' . $this->dashed_to_camelcase( $post->post_name ),
                 'Page' . $post->ID,
@@ -547,9 +547,9 @@ final class DustPress {
             $hierarchy[ 'is_single' ] = [
                 'Single' . $this->dashed_to_camelcase( $template, '_' ),
                 'Single' . $this->dashed_to_camelcase( $template ),
+                $this->dashed_to_camelcase( $template ),
                 'Single' . $this->dashed_to_camelcase( $type, '_' ),
                 'Single' . $this->dashed_to_camelcase( $type ),
-                $this->dashed_to_camelcase( $template ),
                 'Single'
             ];
         }


### PR DESCRIPTION

## [1.34.4] - 2021-10-14
- Fix template usage for CPT posts. Also allow page templates to use any name, as intended in WP.