### PR TITLE
Removed deprecated Serializable (php 8.1) from dust/Dust.php

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+- Removed deprecated `implements \Serializable` (php 8.1) from dust/Dust.php.
+
 ## [1.36.0] - 2021-11-30
 
 ### Fixed

--- a/dust/Dust.php
+++ b/dust/Dust.php
@@ -4,7 +4,7 @@ namespace Dust
     use Dust\Evaluate\Evaluator;
     use Dust\Parse\Parser;
 
-    class Dust implements \Serializable
+    class Dust
     {
         const FILE_EXTENSION = '.dust';
 
@@ -271,5 +271,4 @@ namespace Dust
         }
 
     }
-
 }


### PR DESCRIPTION
Removed deprecated Serializable (php 8.1) from dust/Dust.php