### PR TITLE
Fix compatibility issue with PHP 8.1 and return types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Fixed
+- A compatibility issue with PHP 8.1 and return types in dust/Evaluate/Bodies
+
 ## Released
 
 ## [1.36.3] - 2023-01-11

--- a/dust/Evaluate/Bodies.php
+++ b/dust/Evaluate/Bodies.php
@@ -28,16 +28,16 @@ namespace Dust\Evaluate
          *
          * @return bool
          */
-        public function offsetExists($offset) {
+        public function offsetExists($offset) : bool {
             return $this[ $offset ] != NULL;
         }
 
         /**
          * @param mixed $offset
          *
-         * @return null
+         * @return mixed
          */
-        public function offsetGet($offset) {
+        public function offsetGet($offset) : mixed {
             for($i = 0; $i < count($this->section->bodies); $i++)
             {
                 if($this->section->bodies[ $i ]->key == $offset)
@@ -55,7 +55,7 @@ namespace Dust\Evaluate
          *
          * @throws \Dust\Evaluate\EvaluateException
          */
-        public function offsetSet($offset, $value) {
+        public function offsetSet($offset, $value) : void {
             throw new EvaluateException($this->section, 'Unsupported set on bodies');
         }
 
@@ -64,7 +64,7 @@ namespace Dust\Evaluate
          *
          * @throws \Dust\Evaluate\EvaluateException
          */
-        public function offsetUnset($offset) {
+        public function offsetUnset($offset) : void {
             throw new EvaluateException($this->section, 'Unsupported unset on bodies');
         }
 


### PR DESCRIPTION
Fixed

`Fatal error:  During inheritance of ArrayAccess: Uncaught Whoops\Exception\ErrorException: Return type of Dust\Evaluate\Bodies::offsetSet($offset, $value) should either be compatible with ArrayAccess::offsetSet(mixed $offset, mixed $value): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /var/www/project/vendor/devgeniem/dustpress/dust/Evaluate/Bodies.php:58`

by defining return types according to PHP docs: https://www.php.net/manual/en/class.arrayaccess.php
