### PR TITLE
Hotfix: Changed pagination query_string filter to FILTER_SANITIZE_URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## [pagination-query-string-filter]
 ### Fixed
-- A compatibility issue with PHP 8.1 and return types in dust/Evaluate/Bodies
+- Changed pagination query_string filter to `filter_var( $_SERVER['QUERY_STRING'], FILTER_SANITIZE_URL );`. `htmlspecialchars()` caused a problem with `&` characters and pagination partials.
 
 ## Released
 
@@ -16,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - PHP 8.1 fix: Dust PHP syntax errors.
 - PHP 8.1 fix: FILTER_SANITIZE_STRING fixes.
+- A compatibility issue with PHP 8.1 and return types in dust/Evaluate/Bodies
 
 ## [1.36.3] - 2023-01-11
 

--- a/helpers/pagination.php
+++ b/helpers/pagination.php
@@ -221,11 +221,12 @@ class Pagination extends Helper {
      */
     public function build_page_link() {
 
-        $query_string = htmlspecialchars( $_SERVER['QUERY_STRING'] );
-
+        $query_string = filter_var( $_SERVER['QUERY_STRING'], FILTER_SANITIZE_URL );
         $page_link    = '?';
-        // User passed get parameters
+
+        // User passed get parameters.
         if ( $query_string ) {
+
             // A page queried.
             if ( strpos( $query_string, $this->page_var ) !== false ) {
                 $idx = 1;


### PR DESCRIPTION
Changed pagination query_string filter to `filter_var( $_SERVER['QUERY_STRING'], FILTER_SANITIZE_URL );`. `htmlspecialchars()` caused a problem with `&` characters and pagination partials.