### PR TITLE
Replace mixed return type with #[\ReturnTypeWillChange]

### DIFF
--- a/dust/Evaluate/Bodies.php
+++ b/dust/Evaluate/Bodies.php
@@ -37,7 +37,8 @@ namespace Dust\Evaluate
          *
          * @return mixed
          */
-        public function offsetGet($offset) : mixed {
+        #[\ReturnTypeWillChange]
+        public function offsetGet($offset) {
             for($i = 0; $i < count($this->section->bodies); $i++)
             {
                 if($this->section->bodies[ $i ]->key == $offset)
@@ -70,4 +71,3 @@ namespace Dust\Evaluate
 
     }
 }
-


### PR DESCRIPTION
Heya,

Use of mixed return type bumps PHP version requirement to >= 8.1, while the rest of the code is compatible with PHP >= 7.1. To maintain compatibility and suppress deprecation notices in PHP 8.1+, I've added the #[\ReturnTypeWillChange] attribute to the offsetGet method.

This attribute is used to indicate a planned change to the returned type, as PHP 9 will most likely enforce return types for interface methods like offsetGet. This ensures compatibility with PHP >= 7.1 while preparing for stricter type requirements in future PHP versions.