### PR TITLE
Add #[AllowDynamicProperties] to suppress dynamic property deprecation in PHP 8.2

### DIFF
--- a/dust/Evaluate/Bodies.php
+++ b/dust/Evaluate/Bodies.php
@@ -2,9 +2,8 @@
 namespace Dust\Evaluate
 {
     use Dust\Ast;
-    use \AllowDynamicProperties;
 
-    #[AllowDynamicProperties]
+    #[\AllowDynamicProperties]
     class Bodies implements \ArrayAccess
     {
         /**


### PR DESCRIPTION
This change adds the #[AllowDynamicProperties] attribute to the Bodies class to address PHP 8.2 deprecation warnings related to dynamic property creation. The attribute ensures that dynamic properties can continue to be used without raising warnings, preserving compatibility with existing functionality.