### PR TITLE
Fix underscore handling in archive model names

### DIFF
--- a/dustpress.php
+++ b/dustpress.php
@@ -562,7 +562,10 @@ final class DustPress {
 
                     foreach ( $post_types as $type ) {
                         if ( is_post_type_archive( $type ) ) {
-                            if ( class_exists( 'Archive' . $this->dashed_to_camelcase( $type ) ) ) {
+                            if ( class_exists( 'Archive' . $this->dashed_to_camelcase( $type, '_' ) ) ) {
+                                return 'Archive' . $this->dashed_to_camelcase( $type, '_' );
+                            }
+                            else if ( class_exists( 'Archive' . $this->dashed_to_camelcase( $type ) ) ) {
                                 return 'Archive' . $this->dashed_to_camelcase( $type );
                             }
                             else if ( class_exists( 'Archive' ) ) {


### PR DESCRIPTION
DustPress doesn't handle underscores correctly when determining archive model class names. For example, with a post type `woo_article`, it fails to find `ArchiveWooArticle` class while `SingleWooArticle` works correctly.